### PR TITLE
28b - Change URL to match description

### DIFF
--- a/eNVD Software.postman_collection.json
+++ b/eNVD Software.postman_collection.json
@@ -1890,7 +1890,7 @@
 			],
 			"request": {
 				"url": {
-					"raw": "https://service.uat.nlis.com.au/api/v3/vendordeclaration/consignments?noDraft=false&pageSize=10",
+					"raw": "https://service.uat.nlis.com.au/api/v3/vendordeclaration/consignments?noDraft=true&pageSize=10",
 					"protocol": "https",
 					"host": [
 						"service",
@@ -1938,7 +1938,7 @@
 					"mode": "raw",
 					"raw": ""
 				},
-				"description": "ss"
+				"description": "Returns last 10 consignments for user that are not a draft"
 			},
 			"response": []
 		},


### PR DESCRIPTION
The name for "28b. Get List of Consignments for User (no drafts)" suggests that the request should filter out drafts. However NoDraft is set to false instead of true which allows drafts to be returned.

I've changed NoDraft to true and added a more detailed description to the request