### PR TITLE
Automatically set API_KEY

### DIFF
--- a/eNVD Software.postman_collection.json
+++ b/eNVD Software.postman_collection.json
@@ -24,7 +24,8 @@
 							"postman.setGlobalVariable(\"token2\",responseData.accountsResponse.accounts[1].accountToken);",
 							"postman.setGlobalVariable(\"token3\",responseData.accountsResponse.accounts[2].accountToken);",
 							"postman.setGlobalVariable(\"token4\",responseData.accountsResponse.accounts[3].accountToken);",
-							"postman.setGlobalVariable(\"token5\",responseData.accountsResponse.accounts[3].accountToken);"
+							"postman.setGlobalVariable(\"token5\",responseData.accountsResponse.accounts[3].accountToken);",
+							"postman.setGlobalVariable(\"API_KEY\",responseData.access_token);"
 						]
 					}
 				}
@@ -49,7 +50,7 @@
 					"mode": "raw",
 					"raw": "client_id=yourclientid&client_secret=yourclientsecret&grant_type=password&scope=lpa_scope&username=yourpic-youruserid&password=yourpassword"
 				},
-				"description": ""
+				"description": "On authentication the API_KEY variable will automatically be set to the access token. This can be overriden by specifying the API_KEY as a collection variables if needed"
 			},
 			"response": []
 		},

--- a/eNVD Software.postman_collection.json
+++ b/eNVD Software.postman_collection.json
@@ -20,11 +20,6 @@
 							"tests[\"Content-Type is present\"] = postman.getResponseHeader(\"Content-Type\");",
 							"",
 							"var responseData = JSON.parse(responseBody);",
-							"postman.setGlobalVariable(\"token1\",responseData.accountsResponse.accounts[0].accountToken);",
-							"postman.setGlobalVariable(\"token2\",responseData.accountsResponse.accounts[1].accountToken);",
-							"postman.setGlobalVariable(\"token3\",responseData.accountsResponse.accounts[2].accountToken);",
-							"postman.setGlobalVariable(\"token4\",responseData.accountsResponse.accounts[3].accountToken);",
-							"postman.setGlobalVariable(\"token5\",responseData.accountsResponse.accounts[3].accountToken);",
 							"postman.setGlobalVariable(\"API_KEY\",responseData.access_token);"
 						]
 					}


### PR DESCRIPTION
Use the postman test runner to automatically set the API_KEY variable when "1. AUTH" is executed.

This is set as a global variable which allows it to be overwritten by a collection variable if needed. I had to remove some of the code as it would throw an error preventing the test runner from setting the API_KEY.